### PR TITLE
Use regex for simpler tokenization

### DIFF
--- a/test.js
+++ b/test.js
@@ -169,6 +169,13 @@ describe("Node.js", function()
 
 
 
+		it("ignores an escape character at the end of a pattern", function()
+		{
+			expect( isSQLMatch("string\\", string) ).to.be.true;
+		});
+
+
+
 		it("rejects non-string input", function()
 		{
 			const args = ["", 1, true, {}, [], function(){}];


### PR DESCRIPTION
Has performance benefits, treating consecutive normal characters as a single token.

I haven’t updated browser.js.